### PR TITLE
#28 - updated the style of the PRIVATE text

### DIFF
--- a/client/components/BadgeTable.js
+++ b/client/components/BadgeTable.js
@@ -11,7 +11,18 @@ const TableRowColumn = mui.TableRowColumn;
 const TableHeaderColumn = mui.TableHeaderColumn;
 
 function privacy(project) {
-  return project.private && (<b> (Private)</b>) || '';
+  // TODO - remove the inline style below once main.scss is properly generating main.scss
+  return project.private && (<span className="projectPrivacy" style={{ display: 'inline-block',
+      font: '13px/1.4 Helvetica, arial, nimbussansl, liberationsans, freesans, clean, sans-serif, "Segoe UI Emoji", "Segoe UI Symbol"',
+      padding: '4px 5px 3px',
+      fontSize: '11px',
+      fontWeight: 300,
+      color: '#a1882b',
+      verticalAlign: 'middle',
+      backgroundColor: '#ffefc6',
+      borderRadius: '3px',
+      marginLeft: '1em',
+  }}> PRIVATE</span>) || '';
 }
 
 function githubUrl(project) {

--- a/client/styles/main.scss
+++ b/client/styles/main.scss
@@ -17,5 +17,18 @@
   margin: 10px;
 }
 
+.projectPrivacy {
+    display: inline-block;
+    font: 13px/1.4 Helvetica, arial, nimbussansl, liberationsans, freesans, clean, sans-serif, "Segoe UI Emoji", "Segoe UI Symbol";
+    padding: 4px 5px 3px;
+    font-size: 11px;
+    font-weight: 300;
+    color: #a1882b;
+    vertical-align: middle;
+    background-color: #ffefc6;
+    border-radius: 3px;
+    margin-left: 1em;
+}
+
 .projectView {
 }


### PR DESCRIPTION
- updated the style of the PRIVATE text to match how this appears in github, namely with a beige background and all caps. This was implemented as both an inline style and as a style in main.scss
  Note that main.scss is not building at the time of this check-in, hence the need for the inline style
